### PR TITLE
Lgomez/salesloft oauth

### DIFF
--- a/airbyte-integrations/connectors/source-salesloft/source_salesloft/spec.json
+++ b/airbyte-integrations/connectors/source-salesloft/source_salesloft/spec.json
@@ -5,14 +5,25 @@
     "title": "Source Salesloft Spec",
     "type": "object",
     "required": [
-      "api_key",
+      "client_id",
+      "client_secret",
+      "refresh_token",
       "start_date"
     ],
     "additionalProperties": false,
     "properties": {
-      "api_key": {
+      "client_id": {
         "type": "string",
-        "description": "Salesloft API Key.",
+        "description": "Salesloft client id."
+      },
+      "client_secret": {
+        "type": "string",
+        "description": "Salesloft client secret.",
+        "airbyte_secret": true
+      },
+      "refresh_token": {
+        "type": "string",
+        "description": "Salesloft refresh token.",
         "airbyte_secret": true
       },
       "start_date": {


### PR DESCRIPTION
## Description of the change
This PR updates the new Salesloft source connector to authenticate HTTP requests to Salesloft API with OAuth.

In this first approach, it uses an `api_key` to authenticate with Salesloft. My next step is to update it so that it uses `OAuth` authentication.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (code refactor or system optimization that improves performance)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development